### PR TITLE
Fixed input function for numeric filenames

### DIFF
--- a/PNG To Hex/On-Chip Memory/png_to_3_txt.py
+++ b/PNG To Hex/On-Chip Memory/png_to_3_txt.py
@@ -8,7 +8,7 @@ def hex_to_rgb(num):
 def rgb_to_hex(num):
     h = str(num)
     return int(h[0:4], 16), int(('0x' + h[4:6]), 16), int(('0x' + h[6:8]), 16)
-filename = input("What's the image name? ")
+filename = str(input("What's the image name? "))
 
 im = Image.open("./sprite_originals/" + filename + ".png") #Can be many different formats.
 im = im.convert("RGBA")


### PR DESCRIPTION
If your filename is composed of only numbers, input() makes it an integer which is incompatible with string concatenation. Adding a (somewhat redundant) str() around input() gives desired behavior across wider range of potential filenames.